### PR TITLE
fix: production queue not slowing unit production for build order

### DIFF
--- a/src/main/java/macro/buildorders/TwoRaxAcademy.java
+++ b/src/main/java/macro/buildorders/TwoRaxAcademy.java
@@ -24,8 +24,8 @@ public class TwoRaxAcademy implements BuildOrder {
         buildOrder.add(new PlannedItem(UnitType.Terran_Refinery, 18, PlannedItemStatus.NOT_STARTED, PlannedItemType.BUILDING, 2));
         buildOrder.add(new PlannedItem(UnitType.Terran_Academy, 19, PlannedItemStatus.NOT_STARTED, PlannedItemType.BUILDING, 2));
         buildOrder.add(new PlannedItem(UnitType.Terran_Supply_Depot, 24, PlannedItemStatus.NOT_STARTED, PlannedItemType.BUILDING, 2));
-        buildOrder.add(new PlannedItem(TechType.Stim_Packs, 26, PlannedItemStatus.NOT_STARTED, PlannedItemType.UPGRADE, 2));
-        buildOrder.add(new PlannedItem(UpgradeType.U_238_Shells, 26, PlannedItemStatus.NOT_STARTED, PlannedItemType.UPGRADE, 2));
+        buildOrder.add(new PlannedItem(TechType.Stim_Packs, 26, PlannedItemStatus.NOT_STARTED, PlannedItemType.UPGRADE, UnitType.Terran_Academy, 2));
+        buildOrder.add(new PlannedItem(UpgradeType.U_238_Shells, 26, PlannedItemStatus.NOT_STARTED, PlannedItemType.UPGRADE, UnitType.Terran_Academy, 2));
         buildOrder.add(new PlannedItem(UnitType.Terran_Comsat_Station, 28, PlannedItemStatus.NOT_STARTED, PlannedItemType.ADDON, 2));
         return buildOrder;
     }

--- a/src/main/java/planner/PlannedItem.java
+++ b/src/main/java/planner/PlannedItem.java
@@ -4,12 +4,12 @@ import bwapi.*;
 
 public class PlannedItem {
     private UnitType unitType;
+    private UnitType techBuilding;
     private Integer supply = 0;
     private PlannedItemStatus plannedItemStatus;
     private PlannedItemType plannedItemType;
     private TilePosition buildPosition;
     private Unit assignedBuilder;
-    private Unit techBuilding;
     private TechType techUpgrade;
     private UpgradeType upgradeType;
 
@@ -60,6 +60,23 @@ public class PlannedItem {
         this.techUpgrade = null;
     }
 
+    public PlannedItem(TechType techUpgrade, Integer supply, PlannedItemStatus plannedItemStatus, PlannedItemType plannedItemType, UnitType techBuilding, int priority) {
+        this.techUpgrade = techUpgrade;
+        this.supply = supply;
+        this.plannedItemStatus = plannedItemStatus;
+        this.plannedItemType = plannedItemType;
+        this.techBuilding = techBuilding;
+        this.priority = priority;
+    }
+
+    public PlannedItem(UpgradeType upgradeType, Integer supply, PlannedItemStatus plannedItemStatus, PlannedItemType plannedItemType, UnitType techBuilding, int priority) {
+        this.upgradeType = upgradeType;
+        this.supply = supply;
+        this.plannedItemStatus = plannedItemStatus;
+        this.plannedItemType = plannedItemType;
+        this.techBuilding = techBuilding;
+        this.priority = priority;
+    }
 
     public PlannedItemStatus getPlannedItemStatus() {
         return plannedItemStatus;
@@ -109,11 +126,11 @@ public class PlannedItem {
         this.assignedBuilder = assignedBuilder;
     }
 
-    public Unit getTechBuilding() {
+    public UnitType getTechBuilding() {
         return techBuilding;
     }
 
-    public void setTechBuilding(Unit techBuilding) {
+    public void setTechBuilding(UnitType techBuilding) {
         this.techBuilding = techBuilding;
     }
 


### PR DESCRIPTION
Fixed:

- Production queue not prioritizing buildings and pausing unit production
- Upgrades status not changing or being removed from build queue
- Building requirements check not properly checking if a building has the dependencies to be built
- Production queue endlessly adding thousands of marines
- Production queue prioritizing medics over marines
- Wasting entire mineral bank on adding barracks

Added:

- Priority check for buildings
- PlannedItem constructor to include tech building
- Check for ability to research tech/upgrade
- Check if tech building is not already researching